### PR TITLE
Add repositories for VxP software tools and libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ PikeOS CVA-6 support | [PikeOS](https://www.pikeos.com/) | WI4.3.3 | SYSGO | To 
 LLVM TD from ADL | [ADLTools](https://github.com/nxp-auto-tools/tools_adl) | WI4.2.1, WI4.2.3 | NXP | Design and verification in progress | BSD2 |  
 Cloud Connector | Not published yet | WI 4.3.4 | aicas | To be determined |
 RISC-V Runtime | Not published yet | WI4.4.1 | CEA | Design and verification in progress | Apache |
-VxP Tools and Libraries | Not published yet | WI3.4.2, WI4.2.1, WI4.2.6, WI4.4.1 | CEA | Design and verification in progress | Apache |
+VxP Tools and Libraries | [VXP binutils](https://github.com/CEA-LIST/vxp_binutils.git), [VXP Devkit](https://github.com/CEA-LIST/vxp_devkit.git) | WI3.4.2, WI4.2.1, WI4.2.6, WI4.4.1 | CEA | Design and verification in progress | Apache |
 
 ### TOOLS
 


### PR DESCRIPTION
Two separate repositories for binutils (with support of VxP ISA) and devkit with tools and libraries to program the accelerator